### PR TITLE
Update Mod to DV Build 96

### DIFF
--- a/Multiplayer/Components/SaveGame/StartGameData_ServerSave.cs
+++ b/Multiplayer/Components/SaveGame/StartGameData_ServerSave.cs
@@ -58,7 +58,7 @@ public class StartGameData_ServerSave : AStartGameData
         LicenseManager.Instance.LoadData(saveGameData);
 
         if (saveGameData.GetString(SaveGameKeys.Game_mode) == "FreeRoam")
-            LicenseManager.Instance.GrabAllUnlockables();
+            LicenseManager.Instance.GrabAllGameModeSpecificUnlockables(SaveGameKeys.Game_mode);
         else
             StartingItemsController.Instance.AddStartingItems(saveGameData, true);
 


### PR DESCRIPTION
`LicenseManager.Instance.GrabAllUnlockables()` does not exist as of Build 96. It has been replaced by `LicenseManager.Instance.GrabAllGameModeSpecificUnlockables(string gameMode)`.
To use that Method we can use the SaveGameKeys.Game_mode to specify the game mode.