### PR TITLE
Fixed PlayerSqrDistanceFrom* calculations 

### DIFF
--- a/Multiplayer/Components/MainMenu/MultiplayerPane.cs
+++ b/Multiplayer/Components/MainMenu/MultiplayerPane.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using DV.UIFramework;
 using DV.Utils;
+using Humanizer;
 using Multiplayer.Components.Networking;
+using TMPro;
 using UnityEngine;
 
 namespace Multiplayer.Components.MainMenu;
@@ -39,6 +41,7 @@ public class MultiplayerPane : MonoBehaviour
             return;
 
         popup.labelTMPro.text = Locale.SERVER_BROWSER__IP;
+        popup.GetComponentInChildren<TMP_InputField>().text = Multiplayer.Settings.DefaultRemoteIP;
 
         popup.Closed += result =>
         {
@@ -67,6 +70,7 @@ public class MultiplayerPane : MonoBehaviour
             return;
 
         popup.labelTMPro.text = Locale.SERVER_BROWSER__PORT;
+        popup.GetComponentInChildren<TMP_InputField>().text = Multiplayer.Settings.Port.ToString();
 
         popup.Closed += result =>
         {
@@ -95,6 +99,7 @@ public class MultiplayerPane : MonoBehaviour
             return;
 
         popup.labelTMPro.text = Locale.SERVER_BROWSER__PASSWORD;
+        popup.GetComponentInChildren<TMP_InputField>().text = Multiplayer.Settings.Password;
 
         popup.Closed += result =>
         {

--- a/Multiplayer/Components/Networking/World/NetworkedStation.cs
+++ b/Multiplayer/Components/Networking/World/NetworkedStation.cs
@@ -2,14 +2,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using DV.Logic.Job;
-using DV.Scenarios;
-using Multiplayer.Components.Networking.Train;
-using Multiplayer.Networking.Data;
-using PlaceholderSoftware.WetStuff.Debugging;
 using UnityEngine;
-using Car = DV.Logic.Job.Car;
 
 namespace Multiplayer.Components.Networking.World;
 
@@ -87,6 +81,9 @@ public class NetworkedStation : MonoBehaviour
             Multiplayer.Log("NetworkedStation.UpdateCarPlates() ParallelTasks - not implemented");
         }
 
+        /*
+         * This section could be optimised/refactored
+         */
         if (cars != null)
         {
             Multiplayer.Log("NetworkedStation.UpdateCarPlates() Cars count: " + cars.Count);

--- a/Multiplayer/Multiplayer.csproj
+++ b/Multiplayer/Multiplayer.csproj
@@ -8,6 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Krafs.Publicizer" Version="2.2.1" />
         <Publicize Include="Assembly-CSharp" IncludeCompilerGeneratedMembers="false" />
+        <Publicize Include="DV.CharacterController" IncludeCompilerGeneratedMembers="false" />
         <Publicize Include="DV.Simulation" IncludeCompilerGeneratedMembers="false" />
         <Publicize Include="DV.Utils:DV.Utils.SingletonBehaviour`1._instance" />
     </ItemGroup>
@@ -17,6 +18,7 @@
         <Reference Include="Assembly-CSharp" />
         <Reference Include="CommandTerminal" />
         <Reference Include="DV.BrakeSystem" />
+        <Reference Include="DV.CharacterController" />
         <Reference Include="DV.Common" />
         <Reference Include="DV.ControllerAnchors" />
         <Reference Include="DV.Highlighting" />

--- a/Multiplayer/Multiplayer.csproj
+++ b/Multiplayer/Multiplayer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net48</TargetFramework>
         <LangVersion>latest</LangVersion>
@@ -88,8 +88,6 @@
 
         <!-- Copy to game install folder -->
         <Exec Condition="Exists('$(DvInstallDir)') And '$(OS)' == 'Windows_NT'" Command="powershell -executionpolicy bypass -Command &quot;(../package.ps1 -NoArchive -OutputDirectory '$(DvInstallDir)\Mods')&quot;" />
-        <Exec Condition="Exists('$(DvInstallDir)') And '$(OS)' == 'Windows_NT'" Command="powershell -executionpolicy bypass -Command &quot;(../package.ps1 -NoArchive -OutputDirectory 'D:\SteamLibrary\steamapps\common\Derail Valley 2\Mods')&quot;" />
-        <Exec Condition="Exists('$(DvInstallDir)') And '$(OS)' == 'Windows_NT'" Command="powershell -executionpolicy bypass -Command &quot;(../openScript.ps1)&quot;" />
         <Exec Condition="Exists('$(DvInstallDir)') And '$(OS)' != 'Windows_NT'" Command="pwsh  -Command &quot;(../package.ps1 -NoArchive -OutputDirectory '$(DvInstallDir)/Mods')&quot;" />
     </Target>
 </Project>

--- a/Multiplayer/Multiplayer.csproj
+++ b/Multiplayer/Multiplayer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net48</TargetFramework>
         <LangVersion>latest</LangVersion>

--- a/Multiplayer/Networking/Managers/Client/NetworkClient.cs
+++ b/Multiplayer/Networking/Managers/Client/NetworkClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using DV;
 using DV.Damage;
@@ -109,7 +110,7 @@ public class NetworkClient : NetworkManager
         netPacketProcessor.SubscribeReusable<ClientboundLicenseAcquiredPacket>(OnClientboundLicenseAcquiredPacket);
         netPacketProcessor.SubscribeReusable<ClientboundGarageUnlockPacket>(OnClientboundGarageUnlockPacket);
         netPacketProcessor.SubscribeReusable<ClientboundDebtStatusPacket>(OnClientboundDebtStatusPacket);
-        netPacketProcessor.SubscribeReusable<ClientboudJobPacket>(OnClientboundJobPacket);
+        netPacketProcessor.SubscribeReusable<ClientboundJobPacket>(OnClientboundJobPacket);
     }
 
     #region Net Events
@@ -597,7 +598,7 @@ public class NetworkClient : NetworkManager
         CareerManagerDebtControllerPatch.HasDebt = packet.HasDebt;
     }
 
-    private void OnClientboundJobPacket(ClientboudJobPacket packet)
+    private void OnClientboundJobPacket(ClientboundJobPacket packet)
     {
         if (!StationComponentLookup.Instance.StationControllerFromId(packet.StationId, out StationController station))
         {
@@ -605,7 +606,7 @@ public class NetworkClient : NetworkManager
             return;
         }
 
-        Multiplayer.Log("Received job packet");
+        Multiplayer.Log($"Received job packet. Job count:{packet.Jobs.Count()}");
 
         foreach (var job in packet.Jobs)
         {
@@ -624,6 +625,10 @@ public class NetworkClient : NetworkManager
                 job.ID,
                 (JobLicenses)job.RequiredLicenses
             );
+
+            //Multiplayer.Log($"Job with ID: {job.ID} already exists in station?: {station.logicStation.availableJobs.Contains(newJob)}");
+            //maybe newJob is not creating properly, try reading the ID to test.
+            Multiplayer.Log($"Job with ID: {newJob.ID} already exists in station?: {station.logicStation.availableJobs.Contains(newJob)}");
 
             station.logicStation.AddJobToStation(newJob);
         }

--- a/Multiplayer/Networking/Managers/Client/NetworkClient.cs
+++ b/Multiplayer/Networking/Managers/Client/NetworkClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using DV;
 using DV.Damage;
@@ -12,6 +13,7 @@ using DV.ThingTypes;
 using DV.UI;
 using DV.UIFramework;
 using DV.WeatherSystem;
+using HarmonyLib;
 using LiteNetLib;
 using Multiplayer.Components;
 using Multiplayer.Components.MainMenu;
@@ -628,9 +630,13 @@ public class NetworkClient : NetworkManager
 
             //Multiplayer.Log($"Job with ID: {job.ID} already exists in station?: {station.logicStation.availableJobs.Contains(newJob)}");
             //maybe newJob is not creating properly, try reading the ID to test.
-            Multiplayer.Log($"Job with ID: {newJob.ID} already exists in station?: {station.logicStation.availableJobs.Contains(newJob)}");
+            Multiplayer.Log($"Attempting to add Job with ID {newJob.ID} to station.\r\nExisting jobs are: {station.logicStation.availableJobs.Select(x=>x.ID + "\r\n\t").ToArray().Join()}\r\nDoes the Job already exist in station? {station.logicStation.availableJobs.Where(x => x.ID == newJob.ID).Count() > 0}");
 
             station.logicStation.AddJobToStation(newJob);
+
+            Multiplayer.Log("NetworkedStation.AddJob() Calling UpdateCarPlates()");
+            NetworkedStation.UpdateCarPlates(tasks, job.ID);
+
         }
     }
 

--- a/Multiplayer/Networking/Managers/Server/NetworkServer.cs
+++ b/Multiplayer/Networking/Managers/Server/NetworkServer.cs
@@ -291,11 +291,11 @@ public class NetworkServer : NetworkManager
 
             jobDatas[i] = data;
 
-            Multiplayer.Log("JOB ID: " + jobs[i].ID);
+            Multiplayer.Log("Sending Job with ID: " + jobs[i].ID);
             Multiplayer.Log(JsonConvert.SerializeObject(data));
         }
 
-        SendPacketToAll(new ClientboudJobPacket
+        SendPacketToAll(new ClientboundJobPacket
         {
             StationId = stationId,
             Jobs = jobDatas,

--- a/Multiplayer/Networking/Managers/Server/NetworkServer.cs
+++ b/Multiplayer/Networking/Managers/Server/NetworkServer.cs
@@ -461,6 +461,29 @@ public class NetworkServer : NetworkManager
             SendPacket(peer, ClientboundSpawnTrainSetPacket.FromTrainSet(set), DeliveryMethod.ReliableOrdered);
         }
 
+        //send jobs - do we need a job manager/job IDs to make this easier?
+        foreach(StationController station in StationController.allStations)
+        {
+            List<JobData> jobData = new List<JobData>();
+
+            foreach(Job job in station.logicStation.availableJobs)
+            {
+                jobData.Add(JobData.FromJob(job));
+            }
+
+            SendPacket(peer,
+                        new ClientboundJobPacket
+                            {
+                                Jobs = jobData.ToArray(),
+                                StationId = station.logicStation.ID,
+                                ModInfo = new[] { new ModInfo("6727318026738916", "1.0") } //why do we do this??
+                            },
+                        DeliveryMethod.ReliableOrdered
+                    );
+                
+        }
+
+
         // Send existing players
         foreach (ServerPlayer player in ServerPlayers)
         {

--- a/Multiplayer/Networking/Packets/Clientbound/ClientboundJobPacket.cs
+++ b/Multiplayer/Networking/Packets/Clientbound/ClientboundJobPacket.cs
@@ -2,7 +2,7 @@ using Multiplayer.Networking.Data;
 
 namespace Multiplayer.Networking.Packets.Clientbound;
 
-public class ClientboudJobPacket
+public class ClientboundJobPacket
 {
     public string StationId { get; set; }
     public JobData[] Jobs { get; set; }

--- a/Multiplayer/Patches/Jobs/StationJobGenerationRangePatch.cs
+++ b/Multiplayer/Patches/Jobs/StationJobGenerationRangePatch.cs
@@ -16,10 +16,11 @@ public static class StationJobGenerationRange_PlayerSqrDistanceFromStationCenter
         Vector3 anchor = __instance.stationCenterAnchor.position;
 
         __result = float.MaxValue;
+
         //Loop through all of the players and return the one thats closest to the anchor
         foreach (ServerPlayer serverPlayer in NetworkLifecycle.Instance.Server.ServerPlayers)
         {
-            float sqDist = (serverPlayer.RawPosition - anchor).sqrMagnitude;
+            float sqDist = (serverPlayer.WorldPosition - anchor).sqrMagnitude;
             if (sqDist < __result)
                 __result = sqDist;
         }
@@ -42,7 +43,7 @@ public static class StationJobGenerationRange_PlayerSqrDistanceFromStationOffice
         //Loop through all of the players and return the one thats closest to the anchor
         foreach (ServerPlayer serverPlayer in NetworkLifecycle.Instance.Server.ServerPlayers)
         {
-            float sqDist = (serverPlayer.RawPosition - anchor).sqrMagnitude;
+            float sqDist = (serverPlayer.WorldPosition - anchor).sqrMagnitude;
             if (sqDist < __result)
                 __result = sqDist;
         }

--- a/Multiplayer/Settings.cs
+++ b/Multiplayer/Settings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Humanizer;
 using UnityEngine;
 using UnityModManagerNet;
@@ -21,6 +21,8 @@ public class Settings : UnityModManager.ModSettings, IDrawable
 
     [Space(10)]
     [Header("Server")]
+    [Draw("Default Remote IP", Tooltip = "The default server IP when joining as a client.")]
+    public string DefaultRemoteIP = "";
     [Draw("Password", Tooltip = "The password required to join your server. Leave blank for no password.")]
     public string Password = "";
     [Draw("Max Players", Tooltip = "The maximum number of players that can join your server, including yourself.")]

--- a/Multiplayer/Utils/Csv.cs
+++ b/Multiplayer/Utils/Csv.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -14,7 +15,8 @@ public static class Csv
     /// </summary>
     public static ReadOnlyDictionary<string, Dictionary<string, string>> Parse(string data)
     {
-        string[] lines = data.Split('\n');
+        string[] separators = new string[]{"\r\n" };
+        string[] lines = data.Split(separators, StringSplitOptions.None);
 
         // Dictionary<string, Dictionary<string, string>>
         OrderedDictionary columns = new(lines.Length - 1);


### PR DESCRIPTION
- Merged main branch updates (release 97 fixes)
- Calcs now use player WorldPosition instead of RawPosition. This is inline with the game's internal calcs and gives the correct result.
- Added default settings to the Join popup dialogues
- Added setting storage for a default remote IP address

More work required:

- infinite spawning of blank job sheets on client. Currently investigating
- job sheet duplicates spawned, suspect to do with job packet receival and spawning not detecting job already exists. Currently investigating